### PR TITLE
Use port 5001 by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ You get a live scoreboard.
    source .venv/bin/activate  # Windows: .venv\Scripts\activate
    pip install -r requirements.txt
    ```
-3) Run the app:
+3) Run the app (defaults to port 5001; set `PORT` to change):
    ```bash
-   python -m app
+   python -m app                # or: PORT=8000 python -m app
    ```
-4) Open http://localhost:5000  (You’ll see the scoreboard and a “Facilitator” panel.)
+4) Open http://localhost:5001  (replace 5001 if you set a different `PORT`)
 
 ### Optional: share a public link
 If you want remote folks to join, expose it with Cloudflare Tunnel:
@@ -30,7 +30,7 @@ If you want remote folks to join, expose it with Cloudflare Tunnel:
 cloudflared --version
 
 # 2) Run a quick ad-hoc tunnel
-cloudflared tunnel --url http://localhost:5000
+cloudflared tunnel --url http://localhost:5001   # adjust if you changed `PORT`
 ```
 It prints a public URL (e.g., https://something.trycloudflare.com). Share that URL with attendees.
 

--- a/app/app.py
+++ b/app/app.py
@@ -311,7 +311,7 @@ def main():
     global STATE
     with LOCK:
         STATE = load_state()
-    port = int(os.environ.get("PORT", "5000"))
+    port = int(os.environ.get("PORT", "5001"))
     APP.run(host="0.0.0.0", port=port, debug=False)
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- switch default server port to 5001 since 5000 may be busy
- update documentation to reflect new port
- document how to override the port via `PORT`

## Testing
- `python -m py_compile app/app.py`
- `python -m app & sleep 2; kill $!`


------
https://chatgpt.com/codex/tasks/task_e_68ac5b8eb3d8832197e9da7558d0bf60